### PR TITLE
opOpenSocial:execute-lifecycle-event タスクに関する改善

### DIFF
--- a/lib/task/opOpenSocialExecuteLifecycleEventTask.class.php
+++ b/lib/task/opOpenSocialExecuteLifecycleEventTask.class.php
@@ -114,6 +114,11 @@ EOF;
           {
             $queue->delete();
           }
+          elseif (floor($response->getStatus() / 100) == 4)
+          {
+            // Client error 4xx (e.g. Not Found)
+            break;
+          }
         }
         catch (Zend_Http_Client_Exception $e)
         {

--- a/lib/task/opOpenSocialExecuteLifecycleEventTask.class.php
+++ b/lib/task/opOpenSocialExecuteLifecycleEventTask.class.php
@@ -23,7 +23,7 @@ class opOpenSocialExecuteLifecycleEventTask extends sfDoctrineBaseTask
     $this->name      = 'execute-lifecycle-event';
 
     $this->addOption('application', null, sfCommandOption::PARAMETER_OPTIONAL, 'The application', true);
-    $this->addOption('env', null, sfCommandOption::PARAMETER_REQUIRED, 'The environment', 'dev');
+    $this->addOption('env', null, sfCommandOption::PARAMETER_REQUIRED, 'The environment', 'prod');
     $this->addOption('consumer-key', null, sfCommandOption::PARAMETER_OPTIONAL, 'The consumer key for signing by OAuth', null);
     $this->addOption('limit-request', null, sfCommandOption::PARAMETER_OPTIONAL, 'Limit of request', 0);
     $this->addOption('limit-request-app', null, sfCommandOption::PARAMETER_OPTIONAL, 'Limit of request par an application', 0);
@@ -41,9 +41,7 @@ EOF;
   protected function execute($arguments = array(), $options = array())
   {
     require_once realpath(dirname(__FILE__).'/../../../../lib/vendor/OAuth/OAuth.php');
-
-    new sfDatabaseManager($this->configuration);
-    sfContext::createInstance($this->createConfiguration('pc_frontend', 'prod'), 'pc_frontend');
+    sfContext::createInstance($this->configuration);
 
     $consumerKey = (isset($options['consumer-key']) && $options['consumer-key']) ?
       $options['consumer-key'] :

--- a/lib/task/opOpenSocialExecuteLifecycleEventTask.class.php
+++ b/lib/task/opOpenSocialExecuteLifecycleEventTask.class.php
@@ -106,10 +106,17 @@ EOF;
         }
         $client->setUri($href);
         $client->setHeaders($oauthRequest->to_header());
-        $response = $client->request();
-        if ($response->isSuccessful())
+
+        try
         {
-          $queue->delete();
+          $response = $client->request(); // throws Zend_Http_Client_Exception if failed
+          if ($response->isSuccessful())
+          {
+            $queue->delete();
+          }
+        }
+        catch (Zend_Http_Client_Exception $e)
+        {
         }
 
         $allRequest++;

--- a/lib/task/opOpenSocialExecuteLifecycleEventTask.class.php
+++ b/lib/task/opOpenSocialExecuteLifecycleEventTask.class.php
@@ -49,7 +49,10 @@ EOF;
       opOpenSocialToolKit::getOAuthConsumerKey();
     $consumer = new OAuthConsumer($consumerKey, null, null);
     $signatureMethod = new OAuthSignatureMethod_RSA_SHA1_opOpenSocialPlugin();
+
+    $client = new Zend_Http_Client();
     $httpOptions = opOpenSocialToolKit::getHttpOptions();
+    $client->setConfig($httpOptions);
 
     $queueGroups = Doctrine::getTable('ApplicationLifecycleEventQueue')->getQueueGroups();
 
@@ -88,7 +91,7 @@ EOF;
         $oauthRequest = OAuthRequest::from_consumer_and_token($consumer, null, $method, $href, $queue->getParams());
         $oauthRequest->sign_request($signatureMethod, $consumer, null);
 
-        $client = new Zend_Http_Client();
+        $client->resetParameters();
         if ('post' !== $method)
         {
           $method = 'get';
@@ -101,7 +104,6 @@ EOF;
           $client->setHeaders(Zend_Http_Client::CONTENT_TYPE, Zend_Http_Client::ENC_URLENCODED);
           $client->setRawData($oauthRequest->to_postdata());
         }
-        $client->setConfig($httpOptions);
         $client->setUri($href);
         $client->setHeaders($oauthRequest->to_header());
         $response = $client->request();

--- a/lib/util/opOpenSocialToolKit.class.php
+++ b/lib/util/opOpenSocialToolKit.class.php
@@ -219,6 +219,7 @@ class opOpenSocialToolKit
     }
     $httpOptions['timeout'] = Shindig_Config::get('curl_connection_timeout');
     $httpOptions['maxredirects'] = 0;
+    $httpOptions['keepalive'] = true;
     return $httpOptions;
   }
 


### PR DESCRIPTION
opOpenSocial:execute-lifecycle-event タスクの処理に対していくつかの修正を行いました。

そのうち、
- イベントの送出にKeep-Aliveを使用 (upsilon@e33ef99dac12b5e3a61239192f3f1ba860c3bab8, upsilon@dd468d3bb68480d14198872018cfce8910d0a186)
- Zend_Http_Client_Exception を考慮 (upsilon@f2eeb4eafa747ca5a209f47c02ef5063dde1b83b)
- sfApplicationConfigurationを2度生成していたのを削除 (upsilon@3b80179c5aae9999f44715c1f9c6c95ba4771e98)

は、タスクの挙動自体に変更を行いませんが、
- サーバが4xxエラーを返してきたらそのアプリの処理を飛ばす (upsilon@772b607e9c02be439cf0ae367f87144cd24d3199)
- 5xxエラーなどが複数回返ってきた場合にスキップするオプションを追加 (upsilon@cab71a03b71672b10a933cf345858fe6866a6902)

のコミットは、アプリ提供者側から見た挙動が変わるのでもしかすると問題が起きるかもしれません。（あくまで応答する見込みが無いと判断してのスキップですが）

また、 upsilon@3b80179c5aae9999f44715c1f9c6c95ba4771e98 を適用した上で openpne3/config/databases.yml に

<pre>
prod:
  doctrine:
    param:
      profiler: false
</pre>

を「追記」すると、実行時のメモリ使用量が大幅に少なくなります。
