### PR TITLE
#1933: opOpenSocial:execute-lifecycle-event タスクの limit-request オプションで指定した値を守らない場合がある

### DIFF
--- a/lib/task/opOpenSocialExecuteLifecycleEventTask.class.php
+++ b/lib/task/opOpenSocialExecuteLifecycleEventTask.class.php
@@ -77,6 +77,12 @@ EOF;
 
       foreach ($queues as $queue)
       {
+        $allRequest++;
+        if ($limitRequest && $limitRequest < $allRequest)
+        {
+          break 2;
+        }
+
         if (!isset($linkHash[$queue->getName()]))
         {
           $queue->delete();
@@ -108,12 +114,6 @@ EOF;
         if ($response->isSuccessful())
         {
           $queue->delete();
-        }
-
-        $allRequest++;
-        if ($limitRequest && $limitRequest <= $allRequest)
-        {
-          break 2;
         }
       }
       $application->free(true);


### PR DESCRIPTION
http://redmine.openpne.jp/issues/1933

に対する修正です。
