### PR TITLE
fix application list page doesn't show link to @application_install, even if allowed to install by member (fixes #3936)

### DIFF
--- a/apps/pc_frontend/modules/application/templates/listSuccess.php
+++ b/apps/pc_frontend/modules/application/templates/listSuccess.php
@@ -35,17 +35,17 @@
   'only' => 'sortable',
   'with' => 'Sortable.serialize("order")+"&'.urlencode($form->getCSRFFieldName()).'='.urlencode($form->getCSRFToken()).'"'
 )); ?>
+<?php endif ?>
+<?php if ($isOwner): ?>
 <div class="moreInfo">
 <ul class="moreInfo">
 <li>
 <?php echo link_to(__('App Gallery'), '@application_gallery') ?>
-<?php if ($isOwner): ?>
 <?php if ($isInstallApp): ?>
 <li><?php echo link_to(__('Install new App'), '@application_install') ?></li>
 <?php endif; ?>
 <?php if ($isInstalledApp): ?>
 <li><?php echo link_to(__('Apps Installed by You'), '@application_installed_list') ?></li>
-<?php endif; ?>
 <?php endif; ?>
 </li>
 </ul>


### PR DESCRIPTION
Bug (バグ) #3936: SNSメンバーによるアプリ追加を許可しても「新しいアプリをインストールする」のリンクが表示されない
https://redmine.openpne.jp/issues/3936

上記のバグチケットに対する修正です
